### PR TITLE
Dawnpm indexing improvements

### DIFF
--- a/team/indexing-scripts/README.md
+++ b/team/indexing-scripts/README.md
@@ -32,8 +32,6 @@ pip3.9 install os
 3. `cd` into the folder that contains your script
 4. Run this command: `python3.9 scrape_formatter.py`
 5. The script will run and skip over any files that cause issues. Once it's done, you'll be able to see the processed txt files in the `processed` folder.
-
-
-
-   
-
+6. `cd` into the `processed` folder, and run `cat *.txt >> aggregated`
+7. Then run `gsplit -b 3500K aggregated aggregated- --additional-suffix=".txt"`
+8. The split will create a handful of files (aggregated-aa.txt, aggregated-ab.txt, etc), upload these to the Bulk URL Uploader.

--- a/team/indexing-scripts/scrape_formatter.py
+++ b/team/indexing-scripts/scrape_formatter.py
@@ -2,6 +2,8 @@ import csv
 import pandas as pd
 import os
 
+# to run, enter at the prompt: `python3.9 scrape_formatter.py`
+
 # assign directory
 directory = 'raw'
  
@@ -28,3 +30,6 @@ for filename in os.listdir(directory):
 
         except Exception as e:
             print("Could not proccess " + filename + ". Error: " + str(e))
+
+# when complete, cd into /processed/ run `cat *.txt >> aggregated` from the command line
+# then run `gsplit -b 3500K aggregated aggregated- --additional-suffix=".txt"`


### PR DESCRIPTION
For various reasons, it's helpful for me to have the each-time instructions in the script file itself as a comment. May help others as well.

Background:
When I learned that the bulk uploader would take a mix of domains, as long as they were valid, I began putting all of the RSS Feed Puller lists into a single file for uploading. But that still left the dozens of crawl outputs to upload individually.

Current change:
So I'm adding two post-processing steps - 
1. aggregate all the files that were created by the script into one file
2. split that aggregated file into the right sized chunks for uploading.

Taking these steps mean that we'll have only three or four files to upload, rather than dozens.